### PR TITLE
Deprecate Throws / DoesNotThrow in favour of ThrowsAsync / DoesNotThrowAsync to prevent deadlocks

### DIFF
--- a/Prototest.Example/AssertionTests.cs
+++ b/Prototest.Example/AssertionTests.cs
@@ -81,33 +81,33 @@ namespace Prototest.Example
         }
 
 #if !PLATFORM_UNITY
-        public void TestAsyncThrowsFailure()
+        public async Task TestAsyncThrowsFailure()
         {
-            _assert.Throws<PrototestThrowsFailureException>(() =>
+            await _assert.ThrowsAsync<PrototestThrowsFailureException>(async () =>
             {
-                _assert.Throws<InvalidOperationException>(async () =>
+                await _assert.ThrowsAsync<InvalidOperationException>(async () =>
                 {
                     await Task.Delay(100);
                 });
             });
         }
 
-        public void TestAsyncThrowsAnyFailure()
+        public async Task TestAsyncThrowsAnyFailure()
         {
-            _assert.Throws<PrototestThrowsFailureException>(() =>
+            await _assert.ThrowsAsync<PrototestThrowsFailureException>(async () =>
             {
-                _assert.Throws(async () =>
+                await _assert.ThrowsAsync(async () =>
                 {
                     await Task.Delay(100);
                 });
             });
         }
 
-        public void TestAsyncDoesNotThrowFailure()
+        public async Task TestAsyncDoesNotThrowFailure()
         {
-            _assert.Throws<PrototestDoesNotThrowFailureException>(() =>
+            await _assert.ThrowsAsync<PrototestDoesNotThrowFailureException>(async () =>
             {
-                _assert.DoesNotThrow<InvalidOperationException>(async () =>
+                await _assert.DoesNotThrowAsync<InvalidOperationException>(async () =>
                 {
                     await Task.Delay(100);
                     throw new InvalidOperationException();
@@ -115,11 +115,11 @@ namespace Prototest.Example
             });
         }
 
-        public void TestAsyncDoesNotThrowAnyFailure()
+        public async Task TestAsyncDoesNotThrowAnyFailure()
         {
-            _assert.Throws<PrototestDoesNotThrowFailureException>(() =>
+            await _assert.ThrowsAsync<PrototestDoesNotThrowFailureException>(async () =>
             {
-                _assert.DoesNotThrow(async () =>
+                await _assert.DoesNotThrowAsync(async () =>
                 {
                     await Task.Delay(100);
                     throw new InvalidOperationException();

--- a/Prototest.Library/Version1/IAssert.cs
+++ b/Prototest.Library/Version1/IAssert.cs
@@ -50,14 +50,30 @@ namespace Prototest.Library.Version1
         void DoesNotThrow(Action code, string message);
         void DoesNotThrow<T>(Action code, string message) where T : Exception;
 #if !PLATFORM_UNITY
+        [Obsolete("This method can introduce deadlocks because it is not awaitable; use ThrowsAsync instead.")]
         Exception Throws(Func<Task> code);
+        [Obsolete("This method can introduce deadlocks because it is not awaitable; use ThrowsAsync instead.")]
         T Throws<T>(Func<Task> code) where T : Exception;
+        [Obsolete("This method can introduce deadlocks because it is not awaitable; use ThrowsAsync instead.")]
         Exception Throws(Func<Task> code, string message);
+        [Obsolete("This method can introduce deadlocks because it is not awaitable; use ThrowsAsync instead.")]
         T Throws<T>(Func<Task> code, string message) where T : Exception;
+        [Obsolete("This method can introduce deadlocks because it is not awaitable; use DoesNotThrowAsync instead.")]
         void DoesNotThrow(Func<Task> code);
+        [Obsolete("This method can introduce deadlocks because it is not awaitable; use DoesNotThrowAsync instead.")]
         void DoesNotThrow<T>(Func<Task> code) where T : Exception;
+        [Obsolete("This method can introduce deadlocks because it is not awaitable; use DoesNotThrowAsync instead.")]
         void DoesNotThrow(Func<Task> code, string message);
+        [Obsolete("This method can introduce deadlocks because it is not awaitable; use DoesNotThrowAsync instead.")]
         void DoesNotThrow<T>(Func<Task> code, string message) where T : Exception;
+        Task<Exception> ThrowsAsync(Func<Task> code);
+        Task<T> ThrowsAsync<T>(Func<Task> code) where T : Exception;
+        Task<Exception> ThrowsAsync(Func<Task> code, string message);
+        Task<T> ThrowsAsync<T>(Func<Task> code, string message) where T : Exception;
+        Task DoesNotThrowAsync(Func<Task> code);
+        Task DoesNotThrowAsync<T>(Func<Task> code) where T : Exception;
+        Task DoesNotThrowAsync(Func<Task> code, string message);
+        Task DoesNotThrowAsync<T>(Func<Task> code, string message) where T : Exception;
 #endif
     }
 }


### PR DESCRIPTION
The current implementation of Throws / DoesNotThrow when called with an async method is liable to cause deadlocks due to their use of `Wait()`. Instead, provide true async versions of these methods that don't deadlock and mark the old versions as obsolete.

Existing code can still continue to use Throws / DoesNotThrow, but should migrate when possible to the new versions because it will reduce the likelihood that deadlocks will occur in test code.